### PR TITLE
updated image tags in anticipation for corresponding release

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -13,7 +13,7 @@ x-envoy-common:
 
 services:
   cactus-runner:
-    image: ghcr.io/synergy-au/cactus-runner:22-synergy
+    image: ghcr.io/synergy-au/cactus-runner:23-synergy
     ports:
       - 127.0.0.1:8080:8080
     networks:
@@ -28,7 +28,7 @@ services:
       - ENVOY_ADMIN_URL=http://cactus-envoy-admin:8001
 
   cactus-teststack-init:
-    image: ghcr.io/synergy-au/cactus-teststack-init:22-synergy
+    image: ghcr.io/synergy-au/cactus-teststack-init:23-synergy
     restart: "no"
     environment:
       - ENVOY_DATABASE_URL=postgresql://test_user:test_pwd@cactus-envoy-db/test_db
@@ -57,7 +57,7 @@ services:
         condition: service_completed_successfully
 
   taskiq-worker:
-    image: ghcr.io/synergy-au/cactus-envoy:22-synergy
+    image: ghcr.io/synergy-au/cactus-envoy:23-synergy
     environment:
       <<: *common-env
     command: taskiq worker envoy.notification.main:broker envoy.notification.task
@@ -71,7 +71,7 @@ services:
         condition: service_completed_successfully
 
   cactus-envoy:
-    image: ghcr.io/synergy-au/cactus-envoy:22-synergy
+    image: ghcr.io/synergy-au/cactus-envoy:23-synergy
     ports:
       - 127.0.0.1:8000:8000
     restart: unless-stopped
@@ -92,7 +92,7 @@ services:
       - shared:/shared
 
   cactus-envoy-admin:
-    image: ghcr.io/synergy-au/cactus-envoy:22-synergy
+    image: ghcr.io/synergy-au/cactus-envoy:23-synergy
     ports:
       - 127.0.0.1:8001:8001
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-envoy-common:
 
 services:
   cactus-teststack-init:
-    image: ghcr.io/synergy-au/cactus-teststack-init:22-synergy
+    image: ghcr.io/synergy-au/cactus-teststack-init:23-synergy
     restart: "no"
     environment:
       - ENVOY_DATABASE_URL=postgresql://test_user:test_pwd@cactus-envoy-db/test_db
@@ -43,7 +43,7 @@ services:
         condition: service_completed_successfully
 
   taskiq-worker:
-    image: ghcr.io/synergy-au/cactus-envoy:22-synergy
+    image: ghcr.io/synergy-au/cactus-envoy:23-synergy
     environment:
       <<: *common-env
     command: taskiq worker envoy.notification.main:broker envoy.notification.task
@@ -57,7 +57,7 @@ services:
         condition: service_completed_successfully
 
   cactus-envoy:
-    image: ghcr.io/synergy-au/cactus-envoy:22-synergy
+    image: ghcr.io/synergy-au/cactus-envoy:23-synergy
     ports:
       - 127.0.0.1:8000:8000
     restart: unless-stopped
@@ -79,7 +79,7 @@ services:
       - logs:/app/logs
 
   cactus-envoy-admin:
-    image: ghcr.io/synergy-au/cactus-envoy:22-synergy
+    image: ghcr.io/synergy-au/cactus-envoy:23-synergy
     ports:
       - 127.0.0.1:8001:8001
     restart: unless-stopped


### PR DESCRIPTION
A new release for main cactus deploy was performed while lining `22-synergy` up. New release will now be `23-synergy`. Relates to [AB#193030](https://synergynetau.visualstudio.com/ac8e4582-93b9-4af1-b98f-8f9c340b88e1/_workitems/edit/193030).