### PR TITLE
feat: 196646 create tests interconnection handbook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.11.12,<4",
-  "cactus-test-definitions @ git+https://github.com/synergy-au/cactus-test-definitions.git@csipaus.org/ns/v1.3-beta/storage",
+  "cactus-test-definitions @ git+https://github.com/synergy-au/cactus-test-definitions.git@196646-create-tests-interconnection-handbook",
   "envoy @ git+https://github.com/synergy-au/envoy.git@v0.15.0-synergy.0.1.0",
   "psycopg[binary]>=3.2.5,<4",
   "asyncpg>=0.30.0,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "cactus-runner"
 dynamic = ["version", "readme"]
-authors = [{ name = "Mike Turner", email = "mike.turner@anu.edu.au" }]
-maintainers = [{ name = "Mike Turner", email = "mike.turner@anu.edu.au" }]
+authors = [
+  { name = "Mike Turner", email = "mike.turner@anu.edu.au" }, 
+  { name = "Joe Crowley", email = "joseph.crowley@synergy.net.au" },
+]
+maintainers = [
+  { name = "Mike Turner", email = "mike.turner@anu.edu.au" }, 
+  { name = "Joe Crowley", email = "joseph.crowley@synergy.net.au" },
+]
 description = "Cactus Test Procedure Runner (CSIP-AUS Client Test Harness)"
 keywords = ["CSIP-AUS", "client", "testing", "runner"]
 requires-python = ">=3.12"
@@ -21,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.11.12,<4",
-  "cactus-test-definitions @ git+https://github.com/synergy-au/cactus-test-definitions.git@196646-create-tests-interconnection-handbook",
+  "cactus-test-definitions @ git+https://github.com/synergy-au/cactus-test-definitions.git@csipaus.org/ns/v1.3-beta/storage",
   "envoy @ git+https://github.com/synergy-au/envoy.git@v0.15.0-synergy.0.1.0",
   "psycopg[binary]>=3.2.5,<4",
   "asyncpg>=0.30.0,<1",

--- a/src/cactus_runner/app/evaluator.py
+++ b/src/cactus_runner/app/evaluator.py
@@ -56,6 +56,11 @@ async def resolve_variable(session: AsyncSession, v: NamedVariable | Expression 
                 return await resolvers.resolve_named_variable_der_rating_max_discharge_rate_w(session)
             case NamedVariableType.DERCAPABILITY_RTG_MAX_WH:
                 return await resolvers.resolve_named_variable_der_rating_max_wh(session)
+            # Storage extension
+            case NamedVariableType.DERSETTING_SET_MIN_WH:
+                return await resolvers.resolve_named_variable_der_setting_min_wh(session)
+            case NamedVariableType.DERCAPABILITY_NEG_RTG_MAX_CHARGE_RATE_W:
+                return await resolvers.resolve_named_variable_neg_der_rating_max_charge_rate_w(session)
         raise UnresolvableVariableError(f"Unable to resolve NamedVariable of type {v.variable} ({int(v.variable)})")
     elif isinstance(v, Expression):
         lhs = await resolve_variable(session, v.lhs_operand)

--- a/src/cactus_runner/app/resolvers.py
+++ b/src/cactus_runner/app/resolvers.py
@@ -104,6 +104,16 @@ async def resolve_named_variable_der_setting_max_wh(session: AsyncSession) -> fl
     return float(set_max_wh)
 
 
+# Storage extension
+async def resolve_named_variable_der_setting_min_wh(session: AsyncSession) -> float:
+    site_der_setting = await _select_single_site_der_setting(session, "setMinWh")
+    set_max_wh = common.pow10_to_decimal_value(site_der_setting.min_wh_value, site_der_setting.min_wh_multiplier)
+    if set_max_wh is None:
+        raise errors.UnresolvableVariableError("Unable to extract setMaxWh from DERSetting")
+
+    return float(set_max_wh)
+
+
 """DER Capability"""
 
 
@@ -163,3 +173,8 @@ async def resolve_named_variable_der_rating_max_wh(session: AsyncSession) -> flo
         raise errors.UnresolvableVariableError("Unable to extract rtgMaxWh from DERCapability")
 
     return float(rtg_max_wh)
+
+
+# Storage extension
+async def resolve_named_variable_neg_der_rating_max_charge_rate_w(session: AsyncSession) -> float:
+    return -1.0 * await resolve_named_variable_der_rating_max_charge_rate_w(session)

--- a/tests/unit/app/named_variables/test_der_setting_min_wh.py
+++ b/tests/unit/app/named_variables/test_der_setting_min_wh.py
@@ -1,0 +1,134 @@
+import pytest
+from assertical.fake.generator import generate_class_instance
+from cactus_test_definitions.errors import UnresolvableVariableError
+from envoy.server.model.site import Site, SiteDER, SiteDERSetting
+
+from cactus_runner.app import resolvers
+from cactus_runner.app.database import begin_session
+
+
+@pytest.mark.asyncio
+async def test_resolve_named_variable_der_setting_min_wh_empty(pg_empty_config):
+    """If there is nothing in the DB - fail in a predictable way"""
+    async with begin_session() as session:
+        with pytest.raises(UnresolvableVariableError, match="DERSetting"):
+            await resolvers.resolve_named_variable_der_setting_min_wh(session)
+
+
+@pytest.mark.asyncio
+async def test_resolve_named_variable_der_setting_min_wh_no_setting(pg_base_config):
+    """If there is everything up to (but not including) a DERSetting in the db  - fail in a predictable way"""
+    async with begin_session() as session:
+        session.add(
+            generate_class_instance(
+                Site, site_id=None, aggregator_id=1, site_ders=[generate_class_instance(SiteDER, site_id=None)]
+            )
+        )
+        await session.commit()
+
+    async with begin_session() as session:
+        with pytest.raises(UnresolvableVariableError, match="setMinWh"):
+            await resolvers.resolve_named_variable_der_setting_min_wh(session)
+
+
+@pytest.mark.asyncio
+async def test_resolve_named_variable_der_setting_min_wh_single_setting(pg_base_config):
+    """If there is a single DERSetting in the db  - return it"""
+    min_wh_value = 12345
+    min_wh_multiplier = -2
+    async with begin_session() as session:
+        session.add(
+            generate_class_instance(
+                Site,
+                site_id=None,
+                aggregator_id=1,
+                site_ders=[
+                    generate_class_instance(
+                        SiteDER,
+                        site_id=None,
+                        site_der_setting=generate_class_instance(
+                            SiteDERSetting,
+                            site_der_setting_id=None,
+                            site_der_id=None,
+                            min_wh_value=min_wh_value,
+                            min_wh_multiplier=min_wh_multiplier,
+                        ),
+                    )
+                ],
+            )
+        )
+        await session.commit()
+
+    async with begin_session() as session:
+        result = await resolvers.resolve_named_variable_der_setting_min_wh(session)
+        assert isinstance(result, float)
+        assert result == 123.45
+
+
+@pytest.mark.asyncio
+async def test_resolve_named_variable_der_setting_min_wh_many_settings(pg_base_config):
+    """If there are multiple DERSettings - return the most recent DERSetting"""
+    min_wh_value = 123
+    min_wh_multiplier = 2
+    async with begin_session() as session:
+        session.add(
+            generate_class_instance(
+                Site,
+                seed=1001,
+                site_id=None,
+                aggregator_id=1,
+            )
+        )
+
+        session.add(
+            generate_class_instance(
+                Site,
+                seed=2002,
+                site_id=None,
+                aggregator_id=1,
+                site_ders=[
+                    generate_class_instance(
+                        SiteDER,
+                        seed=2102,
+                        site_id=None,
+                        site_der_setting=generate_class_instance(
+                            SiteDERSetting,
+                            seed=2202,
+                            site_der_setting_id=None,
+                            site_der_id=None,
+                        ),
+                    )
+                ],
+            )
+        )
+
+        # This site's SiteDERSetting should be returned as it's change_time will be the most recent
+        session.add(
+            generate_class_instance(
+                Site,
+                seed=3003,
+                site_id=None,
+                aggregator_id=1,
+                site_ders=[
+                    generate_class_instance(
+                        SiteDER,
+                        seed=3103,
+                        site_id=None,
+                        site_der_setting=generate_class_instance(
+                            SiteDERSetting,
+                            seed=3203,
+                            site_der_setting_id=None,
+                            site_der_id=None,
+                            min_wh_value=min_wh_value,
+                            min_wh_multiplier=min_wh_multiplier,
+                        ),
+                    )
+                ],
+            )
+        )
+        await session.commit()
+
+    async with begin_session() as session:
+        result = await resolvers.resolve_named_variable_der_setting_min_wh(session)
+        assert isinstance(result, float)
+        assert result == 12300

--- a/tests/unit/app/named_variables/test_neg_der_rating_max_charge_rate_w.py
+++ b/tests/unit/app/named_variables/test_neg_der_rating_max_charge_rate_w.py
@@ -1,0 +1,40 @@
+import pytest
+from assertical.fake.generator import generate_class_instance
+from envoy.server.model.site import Site, SiteDER, SiteDERRating
+
+from cactus_runner.app import resolvers
+from cactus_runner.app.database import begin_session
+
+
+@pytest.mark.asyncio
+async def test_resolve_named_variable_neg_der_rating_max_charge_rate_w_single_setting(pg_base_config):
+    """If there is a single DERSetting in the db  - return it"""
+    max_charge_rate_w_value = 12345
+    max_charge_rate_w_multiplier = -2
+    async with begin_session() as session:
+        session.add(
+            generate_class_instance(
+                Site,
+                site_id=None,
+                aggregator_id=1,
+                site_ders=[
+                    generate_class_instance(
+                        SiteDER,
+                        site_id=None,
+                        site_der_rating=generate_class_instance(
+                            SiteDERRating,
+                            site_der_rating_id=None,
+                            site_der_id=None,
+                            max_charge_rate_w_value=max_charge_rate_w_value,
+                            max_charge_rate_w_multiplier=max_charge_rate_w_multiplier,
+                        ),
+                    )
+                ],
+            )
+        )
+        await session.commit()
+
+    async with begin_session() as session:
+        result = await resolvers.resolve_named_variable_neg_der_rating_max_charge_rate_w(session)
+        assert isinstance(result, float)
+        assert result == -123.45


### PR DESCRIPTION
This is takes care of all new implementations needed to support the battery storage extension tests, including `setMinWh` and the temporary fix for negative value for `opModStorageTargetW` by creating a `negRtgMaxChargeRateW`.

Put my name on things. 

Closes AB#196646
