### PR TITLE
Potential fix for code scanning alert no. 18: Log Injection

### DIFF
--- a/src/cactus_runner/app/handler.py
+++ b/src/cactus_runner/app/handler.py
@@ -113,7 +113,8 @@ async def init_handler(request: web.Request):
     if subscription_domain is None:
         logger.info("Subscriptions will NOT be creatable - no valid domain (subscription_domain not set)")
     else:
-        logger.info(f"Subscriptions will restricted to the FQDN '{subscription_domain}'")
+        sanitized_subscription_domain = subscription_domain.replace("\n", "").replace("\r", "")
+        logger.info(f"Subscriptions will restricted to the FQDN '{sanitized_subscription_domain}'")
 
     run_id = request.query.get("run_id", None)
     if run_id is None:


### PR DESCRIPTION
Potential fix for [https://github.com/synergy-au/cactus-runner/security/code-scanning/18](https://github.com/synergy-au/cactus-runner/security/code-scanning/18)

To fix the log injection vulnerability, we should sanitize the `subscription_domain` value before logging it. This can be done by removing any newline (`\n`) and carriage return (`\r`) characters from the value, as is already done for `run_id` later in the same function. The best way to do this is to assign a sanitized version of `subscription_domain` to a new variable (e.g., `sanitized_subscription_domain`) and use that variable in the log message. This change should be made in the `init_handler` function, specifically in the `else` block starting at line 115. No new imports are needed, as string replacement is a built-in operation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
