### PR TITLE
fix: changed all csipaus uris to https://csipaus.org/ns

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-envoy-common:
 
 services:
   cactus-teststack-init:
-    image: cactusimageregistry.azurecr.io/cactus-teststack-init:48-v1.3-beta_storage
+    image: cactusimageregistry.azurecr.io/cactus-teststack-init:59-v1.3-beta_storage
     restart: "no"
     environment:
       - ENVOY_DATABASE_URL=postgresql://test_user:test_pwd@cactus-envoy-db/test_db
@@ -43,7 +43,7 @@ services:
         condition: service_completed_successfully
 
   taskiq-worker:
-    image: cactusimageregistry.azurecr.io/cactus-envoy:48-v1.3-beta_storage
+    image: cactusimageregistry.azurecr.io/cactus-envoy:59-v1.3-beta_storage
     environment:
       <<: *common-env
     command: taskiq worker envoy.notification.main:broker envoy.notification.task
@@ -57,7 +57,7 @@ services:
         condition: service_completed_successfully
 
   cactus-envoy:
-    image: cactusimageregistry.azurecr.io/cactus-envoy:48-v1.3-beta_storage
+    image: cactusimageregistry.azurecr.io/cactus-envoy:59-v1.3-beta_storage
     ports:
       - 127.0.0.1:8000:8000
     restart: unless-stopped
@@ -79,7 +79,7 @@ services:
       - logs:/app/logs
 
   cactus-envoy-admin:
-    image: cactusimageregistry.azurecr.io/cactus-envoy:48-v1.3-beta_storage
+    image: cactusimageregistry.azurecr.io/cactus-envoy:59-v1.3-beta_storage
     ports:
       - 127.0.0.1:8001:8001
     restart: unless-stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
   "aiohttp>=3.11.12,<4",
   "cactus-test-definitions @ git+https://github.com/bsgip/cactus-test-definitions.git@main",
-  "envoy @ git+https://github.com/synergy-au/envoy.git@v0.17.0-storage.0.1.0-rc3",
+  "envoy @ git+https://github.com/synergy-au/envoy.git@v0.17.0-storage.0.1.0-rc4",
   "psycopg[binary]>=3.2.5,<4",
   "asyncpg>=0.30.0,<1",
   "reportlab>=4.4.1,<5",

--- a/src/cactus_runner/schema/csipaus13/csipaus-core.xsd
+++ b/src/cactus_runner/schema/csipaus13/csipaus-core.xsd
@@ -2,8 +2,8 @@
     elementFormDefault="qualified"
     xmlns="urn:ieee:std:2030.5:ns" 
     targetNamespace="urn:ieee:std:2030.5:ns"
-    xmlns:csipaus="https://csipaus.org/ns/v1.3-beta/storage"> 
-    <xs:import schemaLocation="csipaus-ext.xsd" namespace="https://csipaus.org/ns/v1.3-beta/storage"/>
+    xmlns:csipaus="https://csipaus.org/ns"> 
+    <xs:import schemaLocation="csipaus-ext.xsd" namespace="https://csipaus.org/ns"/>
     <xs:redefine schemaLocation="sep.xsd">
       <xs:complexType name="DERControlBase">
         <xs:complexContent>

--- a/src/cactus_runner/schema/csipaus13/csipaus-ext.xsd
+++ b/src/cactus_runner/schema/csipaus13/csipaus-ext.xsd
@@ -1,8 +1,8 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
     elementFormDefault="qualified"
-    xmlns="https://csipaus.org/ns/v1.3-beta/storage" 
+    xmlns="https://csipaus.org/ns" 
     xmlns:bs="urn:ieee:std:2030.5:ns" 
-    targetNamespace="https://csipaus.org/ns/v1.3-beta/storage"> 
+    targetNamespace="https://csipaus.org/ns"> 
 
     <xs:import namespace="urn:ieee:std:2030.5:ns" schemaLocation="sep.xsd"/>
     

--- a/tests/unit/app/test_schema_validator.py
+++ b/tests/unit/app/test_schema_validator.py
@@ -16,7 +16,7 @@ from cactus_runner.app.schema_validator import (
         """
 <DERControlList
     xmlns="urn:ieee:std:2030.5:ns"
-    xmlns:csipaus="https://csipaus.org/ns/v1.3-beta/storage" all="2" href="/derp/0/derc" results="1">
+    xmlns:csipaus="https://csipaus.org/ns" all="2" href="/derp/0/derc" results="1">
     <DERControl replyTo="/rsp" responseRequired="03">
         <mRID>ABCDEF0123456789</mRID>
         <description>Example DERControl 1</description>
@@ -55,11 +55,11 @@ from cactus_runner.app.schema_validator import (
     </DERControl>
 </DERControlList>""",
         """
-<ConnectionPoint xmlns="https://csipaus.org/ns/v1.3-beta/storage">
+<ConnectionPoint xmlns="https://csipaus.org/ns">
     <connectionPointId>1234567890</connectionPointId>
 </ConnectionPoint>""",
         """
-<DERControlBase xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns/v1.3-beta/storage">
+<DERControlBase xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns">
     <csipaus:opModImpLimW>
         <multiplier>0</multiplier>
         <value>20000</value>
@@ -67,7 +67,7 @@ from cactus_runner.app.schema_validator import (
 </DERControlBase>""",
         """
 <DERSettings xsi:schemaLocation="urn:ieee:std:2030.5:ns sep.xsd"
-  xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns/v1.3-beta/storage"
+  xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <setGradW>27</setGradW>
   <setMaxVA>
@@ -109,7 +109,7 @@ def test_validate_xml_valid_xml(xml):
         "",
         "123451",
         '{"foo": 123}',
-        '<ConnectionPoint xmlns="https://csipaus.org/ns/v1.3-beta/storage"><c',
+        '<ConnectionPoint xmlns="https://csipaus.org/ns"><c',
     ],
 )
 def test_validate_xml_not_xml(xml):
@@ -122,13 +122,13 @@ def test_validate_xml_not_xml(xml):
     "xml",
     [
         """
-<ConnectionPoint xmlns="https://csipaus.org/ns/v1.3-beta/storage">
+<ConnectionPoint xmlns="https://csipaus.org/ns">
     <connectionPointId>1234567890</connectionPointId>
     <extraElement/>
 </ConnectionPoint>
 """,  # Extra elements
         """
-<DERControlBase xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns/v1.3-beta/storage">
+<DERControlBase xmlns="urn:ieee:std:2030.5:ns" xmlns:csipaus="https://csipaus.org/ns">
     <csipaus:opModImpLimW>
         <value>20000</value>
         <multiplier>0</multiplier>


### PR DESCRIPTION
This is a temporary solution for namespacing. The intent is to have it changed back to csipaus.org/ns/v1.3-beta/storage eventually after performing further investigation. 

Docker compose image tags are anticipated for the upcoming deployment to help with initial testing, prior to hitting CACTUS proper. 

Closes [AB#204829](https://synergynetau.visualstudio.com/ac8e4582-93b9-4af1-b98f-8f9c340b88e1/_workitems/edit/204829)